### PR TITLE
packit: use tar-pax instead of tar-ustar

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -8,8 +8,7 @@ actions:
     - bash -c "git describe --tags --match '*.*' | awk -F '-' '{ print $2}' "
   create-archive:
     - "make release"
-    - 'bash -c "tar -tf *.tar.bz2 | tail"'
-    - "bash -c 'ls | grep tar.bz2'"
+    - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 jobs:
   - job: tests
     trigger: pull_request

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -259,9 +259,6 @@ options. This includes driver disks, kickstarts, and finding the anaconda
 runtime on NFS/HTTP/FTP servers or local disks.
 
 %prep
-ls -lha %{SOURCE0}
-tar -tf %{SOURCE0}
-cat %{SOURCE0}
 %autosetup -p 1
 
 %build

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,10 @@ AS_IF([test $ANACONDA_RELEASE],
 # This needs to be set before initializing automake
 AC_DISABLE_STATIC
 
-AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 tar-ustar])
+# UIDs in an openshift pod are bigger than what tar-ustar can handle
+# tar-pax can deal with it though
+# https://github.com/hpcng/singularity/issues/670#issuecomment-346104684
+AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
packit-service runs in openshift where pods run with UID as big as
1000420000

tar-ustar is not able to process such files
